### PR TITLE
chore: add banner about data accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 
 Display APIs compatibility across different JavaScript runtimes. The data is automatically generated, based on MDN [`browser-compat-data`](https://github.com/mdn/browser-compat-data) format using the runtime tests from [`mdn-bcd-collector`](https://github.com/openwebdocs/mdn-bcd-collector). Runtimes are displayed with their [WinterCG Runtime Key](https://runtime-keys.proposal.wintercg.org).
 
+> [!WARNING]
+> The current data is not 100% accurate and is auto generated. Please [open an issue](https://github.com/unjs/runtime-compat/issues) if you have spotted any inconsistencies.
+
 ## About the data
 
 The generated data is available in the `packages/runtime-compat-data` directory. It is published to npm as `runtime-compat-data`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <!-- /automd -->
 
-Display APIs compatibility across different JavaScript runtimes. The data is automatically generated, based on MDN [`browser-compat-data`](https://github.com/mdn/browser-compat-data) format using the runtime tests from [`mdn-bcd-collector`](https://github.com/openwebdocs/mdn-bcd-collector). Runtimes are displayed with their [WinterCG Runtime Key](https://runtime-keys.proposal.wintercg.org).
+Display APIs compatibility across different JavaScript runtimes. The data is automatically generated, based on MDN [`browser-compat-data`](https://github.com/mdn/browser-compat-data) format using the runtime tests from [`mdn-bcd-collector`](https://github.com/openwebdocs/mdn-bcd-collector).
 
 > [!WARNING]
 > The current data is not 100% accurate and is auto generated. Please [open an issue](https://github.com/unjs/runtime-compat/issues) if you have spotted any inconsistencies.

--- a/apps/website/src/app.vue
+++ b/apps/website/src/app.vue
@@ -10,15 +10,17 @@
           href="https://github.com/unjs/runtime-compat/tree/main/packages/runtime-compat-data">
           runtime-compat-data
         </ExternalLink>, based on MDN's format.
-        Runtimes are displayed with their <ExternalLink href="https://runtime-keys.proposal.wintercg.org">
-          WinterCG Runtime Key
-        </ExternalLink>.
+      </p>
+      <p class="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4" role="alert">
+        <strong>Note:</strong> The current data is not 100% accurate and is auto generated.
+        Please <ExternalLink href="https://github.com/unjs/runtime-compat/issues">open an issue</ExternalLink> if you
+        have spotted any inconsistencies.
       </p>
       <label class="flex items-center gap-2">
         <input type="checkbox" class="rounded" v-model="winterCGOnly" />
         <span class="text-md text-slate-600">Filter by WinterCG APIs ({{ computedData.winterCGCount }}/{{
-          computedData.totalCount
-        }})</span>
+        computedData.totalCount
+      }})</span>
       </label>
     </div>
     <div class="sticky top-0 z-10 pointer-events-none max-w-full">
@@ -50,6 +52,7 @@
 <script setup lang="ts">
 import runtimeCompatData, { type CompatStatement, type Identifier, type RuntimeName } from 'runtime-compat-data';
 import { changeScroll } from './lib'
+import ExternalLink from './components/ExternalLink.vue';
 
 const runtimes = Object.keys(runtimeCompatData.api.AbortController.__compat?.support ?? {}) as RuntimeName[]
 const selectedRuntimes = useState<string[]>('selectedRuntimes', () => runtimes)


### PR DESCRIPTION
@QuiiBz feel free to amend the message.

I also removed the wintercg key as discussed since we list extra runtimes currently.

<img width="1266" alt="image" src="https://github.com/unjs/runtime-compat/assets/5158436/161b51b9-5a38-4339-bf25-60adec4221c7">
