### PR TITLE
fix(ui): prevent scroll jittering in Firefox and Safari

### DIFF
--- a/apps/website/src/app.vue
+++ b/apps/website/src/app.vue
@@ -25,7 +25,7 @@
     </div>
     <div class="sticky top-0 z-10 pointer-events-none max-w-full">
       <div class="flex gap-1 overflow-x-scroll scrollbar-none bg-white pt-2 pointer-events-auto linked-scroll"
-        @scroll="changeScroll">
+        @scroll.passive="changeScroll">
         <RuntimeCard v-for="runtime in runtimes" :key="runtime" :runtime="runtime"
           :selected="selectedRuntimes.includes(runtime)"
           :coverage="winterCGOnly ? Math.round(computedData.winterCGCoverage[runtime] / computedData.winterCGCount * 100) : undefined" />

--- a/apps/website/src/components/APIRow.vue
+++ b/apps/website/src/components/APIRow.vue
@@ -7,7 +7,7 @@
         {{ name }}
       </h2>
     </a>
-    <ul class="flex flex-col gap-1 overflow-x-scroll scrollbar-none linked-scroll" @scroll="changeScroll">
+    <ul class="flex flex-col gap-1 overflow-x-scroll scrollbar-none linked-scroll" @scroll.passive="changeScroll">
       <li v-for="[api, apiData] in Object.entries(data)" :key="api" class="flex gap-1">
         <a class="absolute transform translate-y-0.5 translate-x-1 md:translate-x-[calc(-100%-20px)] text-sm text-slate-600 group-hover:text-slate-900 transition flex gap-1 items-center hover:underline"
           :href="apiData.mdn_url ?? apiData.__compat.mdn_url" target="_blank">

--- a/apps/website/src/lib.ts
+++ b/apps/website/src/lib.ts
@@ -1,6 +1,17 @@
 let linkedScrolls: NodeListOf<Element>
+let activeScroller: Element;
+let activeScrollerTimeout;
 
 export function changeScroll(event: Event) {
+  // Prevents scrolling jitter from the other elements' scroll events being triggered
+  //
+  if (activeScroller && activeScroller !== event.target) {
+    return;
+  }
+  activeScroller = event.target;
+  clearTimeout(activeScrollerTimeout);
+  activeScrollerTimeout = setTimeout(() => activeScroller = null, 100);
+
   const scroll = (event.target as HTMLElement).scrollLeft
 
   if (!linkedScrolls) {

--- a/apps/website/src/lib.ts
+++ b/apps/website/src/lib.ts
@@ -10,7 +10,9 @@ export function changeScroll(event: Event) {
   }
   activeScroller = event.target;
   clearTimeout(activeScrollerTimeout);
-  activeScrollerTimeout = setTimeout(() => activeScroller = null, 100);
+  activeScrollerTimeout = setTimeout(() => {
+    activeScroller = undefined
+  }, 100);
 
   const scroll = (event.target as HTMLElement).scrollLeft
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

###  Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes an issue with scrolling in Firefox and Safari, caused by the scroll-linked elements firing `scroll` events of their own when they are programmatically scrolled.
