### PR TITLE
fix(ui): Always show support icons

### DIFF
--- a/apps/website/src/components/APIRow.vue
+++ b/apps/website/src/components/APIRow.vue
@@ -9,7 +9,7 @@
     </a>
     <ul class="flex flex-col gap-1 overflow-x-scroll scrollbar-none linked-scroll" @scroll.passive="changeScroll">
       <li v-for="[api, apiData] in Object.entries(data)" :key="api" class="flex gap-1">
-        <a class="absolute transform translate-y-0.5 translate-x-1 xl:translate-x-[calc(-100%-8px)] text-sm text-slate-600 group-hover:text-slate-900 transition flex gap-1 items-center hover:underline"
+        <a class="absolute transform xl:translate-x-[calc(-100%-8px)] p-1 text-sm text-slate-600 group-hover:text-slate-900 transition flex gap-1 items-center hover:underline bg-gradient-to-r from-[#ffffff77] via-[#ffffff77] via-90% to-transparent"
           :href="apiData.mdn_url ?? apiData.__compat.mdn_url" target="_blank">
           <span v-if="apiData.status?.experimental ?? apiData.__compat?.status?.experimental" class="text-blue-600">
             <IconBlend />
@@ -28,8 +28,8 @@
             'bg-lime-100 text-lime-600': value.version_added,
             'bg-red-100 text-red-600': !value.version_added,
           }">
-            <IconCheck v-if="value.version_added" class="h-4 w-4 hidden xl:inline" />
-            <IconCross v-else class="w-4 h-4 hidden xl:inline" />
+            <IconCheck v-if="value.version_added" class="h-4 w-4" />
+            <IconCross v-else class="w-4 h-4" />
           </span>
         </div>
       </li>


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR is a quick follow-up to #88 which changed the support icons to only appear on XL-sized screens.  This is an a11y regression, specifically for colorblindness.  This PR restores the icons and updates them to always display on any screen size.

Additionally, this adds a slight, white gradient background to the text to make it slightly easier to read.  (The text probably shouldn't overlap the compatibility data at all.)

<img width="1013" alt="Screenshot 2024-03-19 at 00 51 20" src="https://github.com/unjs/runtime-compat/assets/5179191/40e0bb94-4409-4f35-9b0b-57a02599dc0d">