### PR TITLE
fix(ui): Increase timeout for scroll stop function

### DIFF
--- a/apps/website/src/lib.ts
+++ b/apps/website/src/lib.ts
@@ -12,7 +12,7 @@ export function changeScroll(event: Event) {
   clearTimeout(activeScrollerTimeout);
   activeScrollerTimeout = setTimeout(() => {
     activeScroller = undefined
-  }, 100);
+  }, 250);
 
   const scroll = (event.target as HTMLElement).scrollLeft
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR intends to resolve the persisting jitteriness in Safari by increasing the timeout before considering a scroll event to have completed.
