### PR TITLE
fix: add nullish coalescent for when `window` isn't yet defined

### DIFF
--- a/apps/website/src/components/ThemeChooser.vue
+++ b/apps/website/src/components/ThemeChooser.vue
@@ -14,7 +14,7 @@ import Moon from "./icon/Moon.vue";
 export default {
   data() {
     return {
-      theme: window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+      theme: window?.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
     }
   },
   mounted() {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Small bug fix that mitigates a TypeError in between when the component first loads and `window` is initialized.
