### PR TITLE
feat: allow running website from root of repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ To generate data for all runtimes, run `pnpm run generate` in the project source
 
 To generate data for an individual runtime, navigate to `generator/runtimes/<runtime>` and run `pnpm start`.
 
+### View the website
+
+To view the website, run `pnpm run website`, then navigate to `localhost:3000`.
+
 ## Limitations
 
 The actual tests are designed to run in browsers, so there may be inconsistencies. For the same reason, they also do not test for any WinterCG-specific features.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint --cache --ext .ts,.js,.mjs,.cjs .",
     "lint:fix": "eslint --cache --ext .ts,.js,.mjs,.cjs . --fix",
     "release": "vitest run packages/runtime-compat-data/test && pnpm run --filter runtime-compat-data release",
-    "test": "vitest"
+    "test": "vitest",
+    "website": "pnpm run --filter \"website\" dev"
   },
   "devDependencies": {
     "@mdn/browser-compat-data": "^5.5.16",


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a `website` command to the project root package.json so that the website server can be started right from the project root.
