### PR TITLE
fix: strip script output before logged JSON

### DIFF
--- a/generator/runtimes/bun/package.json
+++ b/generator/runtimes/bun/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "start": "bun run.ts > data.json",
+    "start": "bun run.ts | ../../../scripts/strip-delimiters.sh > data.json",
     "version": "bun -v"
   },
   "author": "",

--- a/generator/runtimes/bun/run.ts
+++ b/generator/runtimes/bun/run.ts
@@ -2,4 +2,5 @@ import { runTests } from "../../shared/test.js";
 import tests from "../../../vendor/tests.json" assert { type: "json" };
 
 const data = await runTests(tests);
+console.log("RUNTIME_DATA_START");
 console.log(JSON.stringify(data, undefined, 2));

--- a/generator/runtimes/deno/package.json
+++ b/generator/runtimes/deno/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "start": "deno run --unstable-webgpu -A run.ts > data.json"
+    "start": "deno run --unstable-webgpu -A run.ts | ../../../scripts/strip-delimiters.sh > data.json"
   },
   "author": "",
   "license": "MIT"

--- a/generator/runtimes/deno/run.ts
+++ b/generator/runtimes/deno/run.ts
@@ -3,4 +3,5 @@ import tests from "../../../vendor/tests.json" assert { type: "json" };
 import { gpu } from "../../shared/features.ts";
 
 const data = await runTests(tests, gpu);
+console.log("RUNTIME_DATA_START");
 console.log(JSON.stringify(data, undefined, 2));

--- a/generator/runtimes/edge-light/package.json
+++ b/generator/runtimes/edge-light/package.json
@@ -6,7 +6,7 @@
   "main": "dist/run.mjs",
   "scripts": {
     "build": "unbuild",
-    "start": "node dist/run.mjs > data.json",
+    "start": "node dist/run.mjs | ../../../scripts/strip-delimiters.sh > data.json",
     "version": "pnpm list --depth 0 edge-runtime | tail -n 1"
   },
   "type": "module",

--- a/generator/runtimes/edge-light/run.ts
+++ b/generator/runtimes/edge-light/run.ts
@@ -5,4 +5,5 @@ const runtime = new EdgeRuntime();
 globalThis.eval = runtime.evaluate.bind(runtime);
 
 const data = await runTests(tests);
+console.log("RUNTIME_DATA_START");
 console.log(JSON.stringify(data, undefined, 2));

--- a/generator/runtimes/llrt/package.json
+++ b/generator/runtimes/llrt/package.json
@@ -6,7 +6,7 @@
   "main": "dist/run.mjs",
   "scripts": {
     "build": "unbuild",
-    "start": "llrt dist/run.mjs > data.json"
+    "start": "llrt dist/run.mjs | ../../../scripts/strip-delimiters.sh > data.json"
   },
   "type": "module",
   "keywords": [],

--- a/generator/runtimes/llrt/run.ts
+++ b/generator/runtimes/llrt/run.ts
@@ -3,5 +3,6 @@ import tests from "../../../vendor/tests.json";
 
 // eslint-disable-next-line unicorn/prefer-top-level-await
 runTests(tests).then((data) => {
+  console.log("RUNTIME_DATA_START");
   console.log(JSON.stringify(data, undefined, 2));
 });

--- a/generator/runtimes/node/package.json
+++ b/generator/runtimes/node/package.json
@@ -6,7 +6,7 @@
   "main": "dist/run.mjs",
   "scripts": {
     "build": "unbuild",
-    "start": "node dist/run.mjs > data.json"
+    "start": "node dist/run.mjs | ../../../scripts/strip-delimiters.sh > data.json"
   },
   "type": "module",
   "keywords": [],

--- a/generator/runtimes/node/run.ts
+++ b/generator/runtimes/node/run.ts
@@ -2,4 +2,5 @@ import { runTests } from "../../shared/test.js";
 import tests from "../../../vendor/tests.json";
 
 const data = await runTests(tests);
+console.log("RUNTIME_DATA_START");
 console.log(JSON.stringify(data, undefined, 2));

--- a/scripts/strip-delimiters.sh
+++ b/scripts/strip-delimiters.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Strip all lines before the line containing "RUNTIME_DATA_START"
+sed -n '/RUNTIME_DATA_START$/,$ {
+    /RUNTIME_DATA_START$/d
+    p
+}'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The bcd tests now test `console.dir`, which causes them to log output as part of the test. This is causing the generated JSON to break and tests to fail, because currently we just naively write the script output to a JSON file. With this PR I've added a shell script that uses `sed` to strip anything from before a RUNTIME_DATA_START delimiter, menaing that anything printed during the test run itself is ignored.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
