### PR TITLE
fix(deno): specify a URL to enable Location API

### DIFF
--- a/generator/runtimes/deno/package.json
+++ b/generator/runtimes/deno/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "start": "deno run --unstable-webgpu -A run.ts | ../../../scripts/strip-delimiters.sh > data.json"
+    "start": "deno run --unstable-webgpu --location https://mdn-bcd-collector.gooborg.com -A run.ts | ../../../scripts/strip-delimiters.sh > data.json"
   },
   "author": "",
   "license": "MIT"


### PR DESCRIPTION
This PR adds a command line argument to Deno to specify a URL which will enable the Location API.  See https://docs.deno.com/runtime/manual/runtime/location_api#location-api for more details.
