### PR TITLE
fix: formatting of commit message for data update PRs

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -91,5 +91,7 @@ jobs:
           commit-message: "fix: update runtime compat data"
           body: |
             Updates the runtime compat data.
-            Runtime versions: ${{ steps.get-versions.outputs.versions }}
+            Runtime versions:
+            
+            ${{ steps.get-versions.outputs.versions }}
           base: main


### PR DESCRIPTION
This PR fixes a minor issue with the formatting of the commit messages for the commits that update the runtime compat data.

Before:

```md
Updates the runtime compat data.
Runtime versions:  - bun: 1.1.15
 - deno: 1.44.4
 - edge-light: 2.5.9
 - fastly: 3.13.1
 - llrt: 0.1.15-beta
 - netlify: 17.23.1
 - node: 20.14.0
 - wasmer: 0.4.4
 - workerd: 2024-05-12
```

After:
```md
Updates the runtime compat data.
Runtime versions:

 - bun: 1.1.15
 - deno: 1.44.4
 - edge-light: 2.5.9
 - fastly: 3.13.1
 - llrt: 0.1.15-beta
 - netlify: 17.23.1
 - node: 20.14.0
 - wasmer: 0.4.4
 - workerd: 2024-05-12
```
